### PR TITLE
feat(admin): 출신학교 및 전형 검정고시 일반학생 분리

### DIFF
--- a/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/ApplicantInfo/ApplicantInfo.tsx
@@ -15,10 +15,7 @@ const ApplicantInfo = ({ id }: ApplicantInfoProps) => {
 
   const applicantDetails = [
     { label: '이름', data: formDetailData.applicant.name },
-    {
-      label: '주민등록번호',
-      data: formatDate.toShortDateTime(formDetailData.applicant.registrationNumber),
-    },
+    { label: '주민등록번호', data: formDetailData.applicant.registrationNumber },
     { label: '전화번호', data: formatPhoneNumber(formDetailData.applicant.phoneNumber) },
   ];
 

--- a/apps/admin/src/components/form/FormDetail/EducationInfo/EducationInfo.tsx
+++ b/apps/admin/src/components/form/FormDetail/EducationInfo/EducationInfo.tsx
@@ -13,26 +13,28 @@ interface EducationInfoProps {
 const EducationInfo = ({ id }: EducationInfoProps) => {
   const { data: formDetailData } = useFormDetailQuery(id);
   if (!formDetailData) return <Loader />;
-
-  const educationDetails = [
-    {
-      label: '졸업 구분',
-      data: GRADUATION_TYPE_VALUE[formDetailData.education.graduationType],
-    },
-    { label: '출신 학교명', data: formDetailData.education.schoolName },
-    { label: '졸업년도, 합격년도', data: formDetailData.education.graduationYear },
-    { label: '학교 지역', data: formDetailData.education.schoolLocation },
-    { label: '표준학교코드', data: formDetailData.education.schoolCode },
-    {
-      label: '학교 연락처',
-      data: formatPhoneNumber(formDetailData.education.schoolPhoneNumber),
-    },
-    { label: '작성교사 이름', data: formDetailData.education.teacherName },
-    {
-      label: '작성교사 연락처',
-      data: formatPhoneNumber(formDetailData.education.teacherMobilePhoneNumber),
-    },
-  ];
+  const educationDetails =
+    formDetailData.education.graduationType === 'QUALIFICATION_EXAMINATION'
+      ? [{ label: '합격년도', data: formDetailData.education.graduationYear }]
+      : [
+          {
+            label: '졸업 구분',
+            data: GRADUATION_TYPE_VALUE[formDetailData.education.graduationType],
+          },
+          { label: '출신 학교명', data: formDetailData.education.schoolName },
+          { label: '졸업년도', data: formDetailData.education.graduationYear },
+          { label: '학교 지역', data: formDetailData.education.schoolLocation },
+          { label: '표준학교코드', data: formDetailData.education.schoolCode },
+          {
+            label: '학교 연락처',
+            data: formatPhoneNumber(formDetailData.education.schoolPhoneNumber),
+          },
+          { label: '작성교사 이름', data: formDetailData.education.teacherName },
+          {
+            label: '작성교사 연락처',
+            data: formDetailData.education.teacherMobilePhoneNumber,
+          },
+        ];
 
   return (
     <StyledEducationInfo>


### PR DESCRIPTION
## 📄 Summary

> 어드민의 원서 상세 조회 탭에서 출신학교 및 전형 탭에서 일반학생은 합격년도를 없애고, 검정고시는 합격년도만 뜨게 수정해했습니다.
<br>

## 🔨 Tasks

- 일반/검정고시 학생구분

<br>

## 🙋🏻 More
