### PR TITLE
feat: 입학설명회 폼에 학년 추가

### DIFF
--- a/apps/admin/src/components/fair/FairTable/FairTable.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTable.tsx
@@ -14,12 +14,13 @@ const FairTable = ({ dataList }: FairTableProps) => {
     <Column gap={12}>
       <FairTableHeader attendeeId={attendeeId} />
       {dataList?.map(
-        ({ id, schoolName, name, type, phoneNumber, headcount, question }) => (
+        ({ id, schoolName, name, grade, type, phoneNumber, headcount, question }) => (
           <FairTableItem
             key={id}
             id={id}
             schoolName={schoolName}
             name={name}
+            grade={grade}
             type={type}
             phoneNumber={phoneNumber}
             headcount={headcount}

--- a/apps/admin/src/components/fair/FairTable/FairTableHeader/FairTableHeader.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableHeader/FairTableHeader.tsx
@@ -62,6 +62,9 @@ const FairTableHeader = ({ attendeeId }: FairTableHeaderProps) => {
         <Text fontType="p2" width={293}>
           학교
         </Text>
+        <Text fontType="p2" width={60}>
+          학년
+        </Text>
       </Row>
       <Row gap={48}>
         <Text fontType="p2" width={120}>

--- a/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
+++ b/apps/admin/src/components/fair/FairTable/FairTableItem/FairTableItem.tsx
@@ -12,6 +12,7 @@ interface FairTableItemProps {
   schoolName: string;
   id: number;
   name: string;
+  grade: number | null;
   type: string;
   phoneNumber: string;
   headcount: number;
@@ -21,6 +22,7 @@ interface FairTableItemProps {
 const FairTableItem = ({
   schoolName,
   name,
+  grade,
   id,
   type,
   phoneNumber,
@@ -73,6 +75,9 @@ const FairTableItem = ({
         </Text>
         <Text fontType="p2" width={293}>
           {schoolName}
+        </Text>
+        <Text fontType="p2" width={60}>
+          {grade ? `${grade}학년` : '-'}
         </Text>
       </Row>
       <Row gap={48}>

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -35,6 +35,7 @@ export interface AttendeeData {
   id: number;
   schoolName: string;
   name: string;
+  grade: number | null;
   type: string;
   phoneNumber: string;
   headcount: number;

--- a/apps/user/src/components/fair/FairApplicationBox/student/FairStudentApplicationBox.hook.ts
+++ b/apps/user/src/components/fair/FairApplicationBox/student/FairStudentApplicationBox.hook.ts
@@ -17,6 +17,7 @@ export const useInput = () => {
   const [application, setApplication] = useState<FairApplication>({
     schoolName: '',
     name: '',
+    grade: '',
     type: '학생',
     phoneNumber: '',
     headcount: null,
@@ -32,6 +33,10 @@ export const useInput = () => {
     }));
   };
 
+  const handleApplicationDropdownChange = (value: string, name: string) => {
+    setApplication((prev) => ({ ...prev, [name]: value }));
+  };
+
   const handleApplicationTextAreaChange: ChangeEventHandler<HTMLTextAreaElement> = (
     e
   ) => {
@@ -39,7 +44,12 @@ export const useInput = () => {
     setApplication({ ...application, [name]: value });
   };
 
-  return { application, handleApplicationChange, handleApplicationTextAreaChange };
+  return {
+    application,
+    handleApplicationChange,
+    handleApplicationDropdownChange,
+    handleApplicationTextAreaChange,
+  };
 };
 
 export const useAgree = (
@@ -62,6 +72,7 @@ export const useAgree = (
 
     if (!application.schoolName.trim()) missingFields.push('소속학교');
     if (!application.name.trim()) missingFields.push('성함');
+    if (!application.grade) missingFields.push('학년');
     if (!application.phoneNumber.trim()) missingFields.push('연락처');
     if (application.headcount === null || application.headcount === 0) {
       missingFields.push('참석 인원');

--- a/apps/user/src/components/fair/FairApplicationBox/student/FairStudentApplicationBox.tsx
+++ b/apps/user/src/components/fair/FairApplicationBox/student/FairStudentApplicationBox.tsx
@@ -1,6 +1,15 @@
 import React, { useState } from 'react';
 import { color } from '@maru/design-system';
-import { Button, CellInput, Column, Input, RadioGroup, Text, Textarea } from '@maru/ui';
+import {
+  Button,
+  CellInput,
+  Column,
+  Dropdown,
+  Input,
+  RadioGroup,
+  Text,
+  Textarea,
+} from '@maru/ui';
 import { flex } from '@maru/utils';
 import styled from '@emotion/styled';
 import { useAgree, useCTAButton, useInput } from './FairStudentApplicationBox.hook';
@@ -13,8 +22,12 @@ interface FairStudentApplicationBoxProps {
 
 const FairStudentApplicationBox = ({ id }: FairStudentApplicationBoxProps) => {
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const { application, handleApplicationChange, handleApplicationTextAreaChange } =
-    useInput();
+  const {
+    application,
+    handleApplicationChange,
+    handleApplicationDropdownChange,
+    handleApplicationTextAreaChange,
+  } = useInput();
   const { handleSendFairApplication } = useCTAButton(id, application);
   const { agree, handleAgreeChange, handleButtonClick } = useAgree(
     handleSendFairApplication,
@@ -44,6 +57,24 @@ const FairStudentApplicationBox = ({ id }: FairStudentApplicationBoxProps) => {
             onChange={handleApplicationChange}
             errorMessage="소속학교를 입력해주세요."
             isError={isSubmitted && application.schoolName === ''}
+          />
+          <Dropdown
+            label={
+              <>
+                학년{' '}
+                <Text fontType="context" color={color.red}>
+                  *
+                </Text>
+              </>
+            }
+            name="grade"
+            data={['1학년', '2학년', '3학년']}
+            onChange={handleApplicationDropdownChange}
+            value={application.grade}
+            placeholder="-"
+            width={384}
+            isError={isSubmitted && application.grade === ''}
+            errorMessage="학년을 선택해주세요."
           />
           <Input
             label={

--- a/apps/user/src/components/fair/FairApplicationBox/student/FairStudentApplicationBox.tsx
+++ b/apps/user/src/components/fair/FairApplicationBox/student/FairStudentApplicationBox.tsx
@@ -68,7 +68,11 @@ const FairStudentApplicationBox = ({ id }: FairStudentApplicationBoxProps) => {
               </>
             }
             name="grade"
-            data={['1학년', '2학년', '3학년']}
+            data={[
+              { label: '1학년', value: '1' },
+              { label: '2학년', value: '2' },
+              { label: '3학년', value: '3' },
+            ]}
             onChange={handleApplicationDropdownChange}
             value={application.grade}
             placeholder="-"

--- a/apps/user/src/services/fair/api.ts
+++ b/apps/user/src/services/fair/api.ts
@@ -12,7 +12,10 @@ export const postFairApplication = async (
   fairId: number,
   fairApplicationData: FairApplication
 ) => {
-  const { data } = await maru.post(`/fairs/${fairId}`, fairApplicationData);
+  const { data } = await maru.post(`/fairs/${fairId}`, {
+    ...fairApplicationData,
+    grade: fairApplicationData.grade ? Number(fairApplicationData.grade) : null,
+  });
 
   return data;
 };

--- a/apps/user/src/types/fair/client.ts
+++ b/apps/user/src/types/fair/client.ts
@@ -11,6 +11,7 @@ export interface Fair {
 export interface FairApplication {
   schoolName: string;
   name: string;
+  grade?: string;
   type: string;
   phoneNumber: string;
   headcount?: number | null;

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -67,6 +67,12 @@ const Dropdown = ({
     }
   };
 
+  const selectedItem = (data as (Data | string)[]).find(
+    (item) => (typeof item === 'string' ? item : item.value) === value
+  );
+  const selectedLabel =
+    selectedItem && typeof selectedItem !== 'string' ? selectedItem.label : value;
+
   return (
     <div ref={dropdownRef} style={{ width }}>
       {label && <Label>{label}</Label>}
@@ -79,7 +85,7 @@ const Dropdown = ({
         disabled={disabled}
       >
         <Text fontType="p2" color={value ? color.gray900 : color.gray500} ellipsis={true}>
-          {value || placeholder}
+          {selectedLabel || placeholder}
         </Text>
         {isOpen ? (
           <IconArrowTop color={color.gray600} width={24} height={24} />

--- a/packages/ui/src/Dropdown/Dropdown.tsx
+++ b/packages/ui/src/Dropdown/Dropdown.tsx
@@ -7,6 +7,7 @@ import React from 'react';
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 import Text from '../Text/Text';
+import ConditionalMessage from '../Input/ConditionalMessage';
 
 type DropdownSizeOption = 'MEDIUM' | 'SMALL';
 
@@ -16,7 +17,7 @@ interface Data {
 }
 
 interface DropdownProps {
-  label?: string;
+  label?: string | React.ReactNode;
   data: Data[] | string[];
   width?: CSSProperties['width'];
   size?: DropdownSizeOption;
@@ -26,6 +27,7 @@ interface DropdownProps {
   placeholder?: string;
   doubled?: number;
   isError?: boolean;
+  errorMessage?: string;
   disabled?: boolean;
   background?: 'White' | 'Gray';
 }
@@ -41,6 +43,7 @@ const Dropdown = ({
   placeholder,
   doubled,
   isError = false,
+  errorMessage,
   background = 'White',
   disabled = false,
 }: DropdownProps) => {
@@ -101,6 +104,7 @@ const Dropdown = ({
           })}
         </DropdownList>
       </DropdownListBox>
+      <ConditionalMessage isError={isError} errorMessage={errorMessage} />
     </div>
   );
 };


### PR DESCRIPTION
## 📄 Summary

> 입학 설명회 폼에 학년 입력을 추가하였습니다.

<br>

## 🔨 Tasks

- 입학 설명회 학생 신청 폼에 학년 드롭다운 추가 (1~3학년, 필수값 검증 포함)
- 신청 API 요청 시 grade를 `number | null`로 변환하여 전송
- 어드민 설명회 상세 참가자 테이블에 학년 컬럼 추가 (미입력 시 `-` 표시)
- Dropdown 컴포넌트 개선
  - `label`에 ReactNode 허용 및 `errorMessage` 표시 지원
  - label/value 데이터 사용 시 선택된 값의 label이 표시되도록 수정

<br>

## 🙋🏻 More

교사용 신청 폼에서는 수정사항이 없습니다.