### PR TITLE
fix(user): 인증번호 api 중복 요청 방지 및 UI 오류 수정

### DIFF
--- a/apps/user/src/components/fair/FairList/FairItem/FairItem.tsx
+++ b/apps/user/src/components/fair/FairList/FairItem/FairItem.tsx
@@ -33,12 +33,15 @@ const FairItem = ({
           <Text fontType="code">{formatStatus(status)}</Text>
         </StatusBox>
       </Row>
-      <Text fontType="p2" color={color.gray500}>
-        <EllipsisText>장소: {place}</EllipsisText>
-        <br />
-        신청 기한: {formatApplicationDate(applicationStartDate)} ~{' '}
-        {formatApplicationDate(applicationEndDate)}
-      </Text>
+      <div>
+        <Text fontType="p2" color={color.gray500} ellipsis width="100%" tag="p">
+          장소: {place}
+        </Text>
+        <Text fontType="p2" color={color.gray500} tag="p">
+          신청 기한: {formatApplicationDate(applicationStartDate)} ~{' '}
+          {formatApplicationDate(applicationEndDate)}
+        </Text>
+      </div>
     </StyledFairItem>
   );
 };
@@ -75,13 +78,4 @@ const StatusBox = styled.div<{ status: string }>`
     status === 'APPLICATION_IN_PROGRESS' || status === 'APPLICATION_NOT_STARTED'
       ? color.haeMaruDefault
       : color.red};
-`;
-
-const EllipsisText = styled(Text)`
-  display: inline-block;
-  max-width: 336px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  vertical-align: bottom;
 `;

--- a/apps/user/src/components/main/ScheduleList/ScheduleList.tsx
+++ b/apps/user/src/components/main/ScheduleList/ScheduleList.tsx
@@ -34,7 +34,7 @@ const ScheduleList = () => {
       endTime: dayjs(SCHEDULE.일차_합격_발표).endOf('day'),
     },
     {
-      id: 3,
+      id: 4,
       title: '면접 전형일',
       date: formatScheduleDate(
         [SCHEDULE.이차_면접, SCHEDULE.이차_면접_종료],
@@ -44,14 +44,14 @@ const ScheduleList = () => {
       endTime: SCHEDULE.이차_면접_종료,
     },
     {
-      id: 4,
+      id: 5,
       title: '합격자 발표',
       date: formatScheduleDate([SCHEDULE.최종_합격_발표]),
       startTime: SCHEDULE.최종_합격_발표,
       endTime: dayjs(SCHEDULE.최종_합격_발표).endOf('day'),
     },
     {
-      id: 5,
+      id: 6,
       title: '입학등록기간',
       date: formatScheduleDate(
         [SCHEDULE.입학_등록, SCHEDULE.입학_등록_마감],

--- a/apps/user/src/components/password/passwordContent/passwordContent.hook.ts
+++ b/apps/user/src/components/password/passwordContent/passwordContent.hook.ts
@@ -1,5 +1,5 @@
 import type { ChangeEventHandler } from 'react';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useChangePasswordStore } from '@/stores/user/changePassword';
 import {
   useChangePasswordMutation,
@@ -23,33 +23,54 @@ export const useInput = () => {
   return { changePassword, handleChangePasswordChange };
 };
 
-export const useVerificationCodeAction = (changePasswordData: SignUp) => {
-  const [isVerificationCodeDisabled, setIsVerificationCodeDisabled] = useState(false);
+const RESEND_COOLDOWN_MS = 5000;
+
+export const useVerificationCodeAction = (
+  changePasswordData: SignUp,
+  onRequestSuccess?: () => void
+) => {
+  const [isResendCoolingDown, setIsResendCoolingDown] = useState(false);
   const [isVerificationCodeSent, setIsVerificationCodeSent] = useState(false);
   const [isVerificationCodeConfirmed, setIsVerificationCodeConfirmed] = useState(false);
   const { toast } = useToast();
   const { verificationMutate } = useVerificationMutation(setIsVerificationCodeConfirmed);
 
-  const { requestVerificationMutate } = useRequestUserVerificationMutation({
+  const { requestVerificationMutate, restMutation } = useRequestUserVerificationMutation({
     phoneNumber: changePasswordData.phoneNumber,
     type: 'UPDATE_PASSWORD',
   });
+  const isRequestPending = restMutation.isPending;
+
+  const cooldownTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleRequestVerificationCode = () => {
+    if (isRequestPending || isResendCoolingDown) return;
+
     if (changePasswordData.phoneNumber.replace(/\D/g, '').length < 11) {
       toast('올바른 전화번호를 입력해주세요.', 'ERROR');
-    } else {
-      requestVerificationMutate();
-
-      setIsVerificationCodeDisabled(true);
-      setIsVerificationCodeSent(true);
-      setIsVerificationCodeConfirmed(false);
-
-      setTimeout(() => {
-        setIsVerificationCodeDisabled(false);
-      }, 5000);
+      return;
     }
+
+    requestVerificationMutate(undefined, {
+      onSuccess: () => {
+        setIsVerificationCodeSent(true);
+        setIsVerificationCodeConfirmed(false);
+        setIsResendCoolingDown(true);
+        cooldownTimerRef.current = setTimeout(() => {
+          setIsResendCoolingDown(false);
+        }, RESEND_COOLDOWN_MS);
+        onRequestSuccess?.();
+      },
+    });
   };
+
+  useEffect(() => {
+    return () => {
+      if (cooldownTimerRef.current) {
+        clearTimeout(cooldownTimerRef.current);
+      }
+    };
+  }, []);
 
   const handleVerificationConfirm = () => {
     if (changePasswordData.code.trim().length === 0) {
@@ -65,7 +86,7 @@ export const useVerificationCodeAction = (changePasswordData: SignUp) => {
   };
 
   return {
-    isVerificationCodeDisabled,
+    isVerificationCodeDisabled: isRequestPending || isResendCoolingDown,
     isVerificationCodeSent,
     isVerificationCodeConfirmed,
     handleRequestVerificationCode,

--- a/apps/user/src/components/password/passwordContent/passwordContent.tsx
+++ b/apps/user/src/components/password/passwordContent/passwordContent.tsx
@@ -20,18 +20,17 @@ const PasswordContent = () => {
   const [timerTime, setTimerTime] = useState(0);
   const { handleChangePassword } = useChangePasswordAction(changePassword);
 
+  const startTimer = () => {
+    setTimerTime(300);
+  };
+
   const {
     isVerificationCodeDisabled,
     isVerificationCodeSent,
     isVerificationCodeConfirmed,
     handleRequestVerificationCode,
     handleVerificationConfirm,
-  } = useVerificationCodeAction(changePassword);
-
-  const handleSendVerificationCode = () => {
-    handleRequestVerificationCode();
-    setTimerTime(300);
-  };
+  } = useVerificationCodeAction(changePassword, startTimer);
 
   return (
     <Column gap={128}>
@@ -48,7 +47,7 @@ const PasswordContent = () => {
           placeholder="- 없이 입력해주세요."
           width="100%"
           buttonText={isVerificationCodeSent ? '재전송' : '인증번호 전송'}
-          onClick={handleSendVerificationCode}
+          onClick={handleRequestVerificationCode}
           type="phoneNumber"
           name="phoneNumber"
           onChange={handleChangePasswordChange}

--- a/apps/user/src/components/signup/SignUpContent/SignUpContent.hook.ts
+++ b/apps/user/src/components/signup/SignUpContent/SignUpContent.hook.ts
@@ -27,38 +27,51 @@ export const useSignUpAction = (signUpData: SignUp, termsAgree: boolean) => {
   return { handleSignUp };
 };
 
-export const useVerificationCodeAction = (signUpData: SignUp) => {
+const RESEND_COOLDOWN_MS = 5000;
+
+export const useVerificationCodeAction = (
+  signUpData: SignUp,
+  onRequestSuccess?: () => void
+) => {
   const [isVerificationCodeSent, setIsVerificationCodeSent] = useState(false);
-  const [isVerificationCodeDisabled, setIsVerificationCodeDisabled] = useState(false);
+  const [isResendCoolingDown, setIsResendCoolingDown] = useState(false);
   const [isVerificationCodeConfirmed, setIsVerificationCodeConfirmed] = useState(false);
   const { toast } = useToast();
-  const { requestVerificationMutate } = useRequestUserVerificationMutation({
+  const { requestVerificationMutate, restMutation } = useRequestUserVerificationMutation({
     phoneNumber: signUpData.phoneNumber,
     type: 'SIGNUP',
   });
+  const isRequestPending = restMutation.isPending;
   const [signUp] = useSignUpStore();
   const { verificationMutate } = useVerificationMutation(setIsVerificationCodeConfirmed);
 
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
+  const cooldownTimerRef = useRef<NodeJS.Timeout | null>(null);
 
   const handleRequestVerificationCode = () => {
+    if (isRequestPending || isResendCoolingDown) return;
+
     if (signUp.phoneNumber.replace(/\D/g, '').length < 11) {
       toast('올바른 전화번호를 입력해주세요.', 'ERROR');
-    } else {
-      timerRef.current = setTimeout(() => {
-        requestVerificationMutate();
-        setIsVerificationCodeDisabled(false);
-        setIsVerificationCodeDisabled(true);
+      return;
+    }
+
+    requestVerificationMutate(undefined, {
+      onSuccess: () => {
         setIsVerificationCodeSent(true);
         setIsVerificationCodeConfirmed(false);
-      }, 5000);
-    }
+        setIsResendCoolingDown(true);
+        cooldownTimerRef.current = setTimeout(() => {
+          setIsResendCoolingDown(false);
+        }, RESEND_COOLDOWN_MS);
+        onRequestSuccess?.();
+      },
+    });
   };
 
   useEffect(() => {
     return () => {
-      if (timerRef.current) {
-        clearTimeout(timerRef.current);
+      if (cooldownTimerRef.current) {
+        clearTimeout(cooldownTimerRef.current);
       }
     };
   }, []);
@@ -79,7 +92,7 @@ export const useVerificationCodeAction = (signUpData: SignUp) => {
   return {
     handleRequestVerificationCode,
     handleVerificationCodeConfirm,
-    isVerificationCodeDisabled,
+    isVerificationCodeDisabled: isRequestPending || isResendCoolingDown,
     isVerificationCodeConfirmed,
     isVerificationCodeSent,
   };

--- a/apps/user/src/components/signup/SignUpContent/SignUpContent.tsx
+++ b/apps/user/src/components/signup/SignUpContent/SignUpContent.tsx
@@ -24,18 +24,19 @@ const SignUpContent = () => {
   const [timerTime, setTimerTime] = useState(0);
 
   const { signUp, handleSignUpChange } = useInput();
+
+  const startTimer = () => {
+    setTimerTime(300);
+  };
+
   const {
     handleRequestVerificationCode,
     handleVerificationCodeConfirm,
     isVerificationCodeDisabled,
     isVerificationCodeConfirmed,
     isVerificationCodeSent,
-  } = useVerificationCodeAction(signUp);
+  } = useVerificationCodeAction(signUp, startTimer);
   const { handleSignUp } = useSignUpAction(signUp, termsAgree);
-
-  const startTimer = () => {
-    setTimerTime(300);
-  };
 
   return (
     <StyleSignupContent>
@@ -63,10 +64,7 @@ const SignUpContent = () => {
             name="phoneNumber"
             label="전화번호 인증"
             buttonText={isVerificationCodeSent ? '재전송' : '인증번호 전송'}
-            onClick={() => {
-              handleRequestVerificationCode();
-              startTimer();
-            }}
+            onClick={handleRequestVerificationCode}
             maxLength={11}
             type="phoneNumber"
             placeholder="- 없이 입력해주세요."


### PR DESCRIPTION
## 📄 Summary

> 회원가입 시 인증번호 api 중복 요청을 방지하고, 기존 UI 오류를 수정했습니다.

<br>

## 🔨 Tasks

- 회원가입 인증 요청이 setTimeout으로 5초 지연 후 전송되던 로직 제거 (클릭 즉시 요청)
- 타이머(300초)·전송됨 상태·재전송 쿨다운을 mutation `onSuccess` 시점에만 시작하도록 변경
- `isPending` + 쿨다운 상태로 요청 진행 중/쿨다운 중 버튼 비활성화 및 중복 요청 차단
- 컴포넌트 언마운트 시 쿨다운 타이머 정리(clearTimeout) 처리

<br>

## 🙋🏻 More

요청이 실패하면 타이머가 시작되지 않으므로, 사용자는 바로 재시도할 수 있습니다.