### PR TITLE
fix(user): 인증번호 확인 요청 연타 방지 및 인터셉터의 인증 401 오인 처리

### DIFF
--- a/apps/user/src/apis/instance/instance.ts
+++ b/apps/user/src/apis/instance/instance.ts
@@ -22,6 +22,9 @@ maru.interceptors.request.use(
   (error) => Promise.reject(error)
 );
 
+// 백엔드가 인증 실패류를 모두 401로 응답하므로, 토큰 문제일 때만 재발급을 시도하도록 에러 코드로 구분한다
+const TOKEN_ERROR_CODES = ['EXPIRED_TOKEN', 'INVALID_TOKEN', 'EMPTY_TOKEN'];
+
 interface FailedRequest {
   resolve: (token: string) => void;
   reject: (error?: unknown) => void;
@@ -48,10 +51,13 @@ maru.interceptors.response.use(
       _retry?: boolean;
     };
 
+    const errorCode = (error.response?.data as { code?: string } | undefined)?.code;
+
     const isTokenExpired =
       error.response?.status === 401 &&
       !originalRequest._retry &&
-      Storage.getItem(TOKEN.REFRESH);
+      Storage.getItem(TOKEN.REFRESH) &&
+      TOKEN_ERROR_CODES.includes(errorCode ?? '');
 
     if (isTokenExpired) {
       if (isRefreshing) {

--- a/apps/user/src/apis/instance/instance.ts
+++ b/apps/user/src/apis/instance/instance.ts
@@ -65,7 +65,7 @@ maru.interceptors.response.use(
             };
             return maru(originalRequest);
           })
-          .catch(Promise.reject);
+          .catch((err) => Promise.reject(err));
       }
 
       originalRequest._retry = true;
@@ -83,7 +83,7 @@ maru.interceptors.response.use(
         const newAccessToken = res.data.data.accessToken;
 
         if (!newAccessToken) {
-          alert('다시 로그인 해주세요');
+          throw new Error('토큰 재발급 응답에 accessToken이 없습니다.');
         }
 
         Storage.setItem(TOKEN.ACCESS, newAccessToken);
@@ -97,8 +97,17 @@ maru.interceptors.response.use(
         return maru(originalRequest);
       } catch (refreshError) {
         processQueue(refreshError, null);
-        localStorage.clear();
-        window.location.href = '/login';
+
+        const isAuthError =
+          axios.isAxiosError(refreshError) &&
+          [401, 403].includes(refreshError.response?.status ?? 0);
+
+        if (isAuthError) {
+          Storage.removeItem(TOKEN.ACCESS);
+          Storage.removeItem(TOKEN.REFRESH);
+          window.location.href = '/login';
+        }
+
         return Promise.reject(refreshError);
       } finally {
         isRefreshing = false;

--- a/apps/user/src/components/password/passwordContent/passwordContent.hook.ts
+++ b/apps/user/src/components/password/passwordContent/passwordContent.hook.ts
@@ -33,7 +33,9 @@ export const useVerificationCodeAction = (
   const [isVerificationCodeSent, setIsVerificationCodeSent] = useState(false);
   const [isVerificationCodeConfirmed, setIsVerificationCodeConfirmed] = useState(false);
   const { toast } = useToast();
-  const { verificationMutate } = useVerificationMutation(setIsVerificationCodeConfirmed);
+  const { verificationMutate, restMutation: confirmMutation } = useVerificationMutation(
+    setIsVerificationCodeConfirmed
+  );
 
   const { requestVerificationMutate, restMutation } = useRequestUserVerificationMutation({
     phoneNumber: changePasswordData.phoneNumber,
@@ -73,6 +75,8 @@ export const useVerificationCodeAction = (
   }, []);
 
   const handleVerificationConfirm = () => {
+    if (confirmMutation.isPending || isVerificationCodeConfirmed) return;
+
     if (changePasswordData.code.trim().length === 0) {
       toast('인증 코드를 입력해주세요', 'ERROR');
       return;

--- a/apps/user/src/components/signup/SignUpContent/SignUpContent.hook.ts
+++ b/apps/user/src/components/signup/SignUpContent/SignUpContent.hook.ts
@@ -43,7 +43,9 @@ export const useVerificationCodeAction = (
   });
   const isRequestPending = restMutation.isPending;
   const [signUp] = useSignUpStore();
-  const { verificationMutate } = useVerificationMutation(setIsVerificationCodeConfirmed);
+  const { verificationMutate, restMutation: confirmMutation } = useVerificationMutation(
+    setIsVerificationCodeConfirmed
+  );
 
   const cooldownTimerRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -77,6 +79,8 @@ export const useVerificationCodeAction = (
   }, []);
 
   const handleVerificationCodeConfirm = () => {
+    if (confirmMutation.isPending || isVerificationCodeConfirmed) return;
+
     if (!signUpData.code) {
       toast('인증번호를 입력해주세요', 'ERROR');
       return;


### PR DESCRIPTION
## 📄 Summary

> 토큰 재발급 실패 시 불필요한 로그아웃 방지 및 인증번호 확인 중복 요청 수정

<br>

## 🔨 Tasks

- 재발급 실패가 401/403일 때만 토큰 삭제 및 로그인 페이지 이동 (네트워크 오류 시 로그아웃 방지)
- `localStorage.clear()` 대신 토큰 키만 삭제
- 토큰 에러 코드(`EXPIRED_TOKEN` 등)일 때만 재발급 시도하도록 인터셉터 조건 수정
- 인증번호 확인 버튼 연타 시 중복 요청 방지

<br>

## 🙋🏻 More
