### PR TITLE
fix(admin): 입학설명회 수정 시 일시 표시 오류 및 필드명 불일치 수정

### DIFF
--- a/apps/admin/src/components/fair/EditFairForm/editFairForm.hooks.ts
+++ b/apps/admin/src/components/fair/EditFairForm/editFairForm.hooks.ts
@@ -1,12 +1,17 @@
+import { formatFairRequestBody } from '@/components/fair/FairForm/fair.hooks';
 import { useDeleteFairMutation, usePutFairMutation } from '@/services/fair/mutations';
 import { useFairDetailQuery } from '@/services/fair/queries';
-import type { Fair, FairFormInput } from '@/types/fair/client';
+import type { FairFormInput } from '@/types/fair/client';
 import { useEffect, useState } from 'react';
 
+// 서버 응답의 ISO 형식("2026-09-05T11:00:00")을 폼에서 쓰는 12자리("202609051100")로 변환
+const toRawDateTime = (isoDateTime: string) =>
+  isoDateTime.replace(/\D/g, '').slice(0, 12);
+
 export const useEditFairForm = (fairId: number) => {
-  const [editFair, setEditFair] = useState<Fair>({
+  const [editFair, setEditFair] = useState<FairFormInput>({
     start: '',
-    capacity: 0,
+    capacity: '',
     place: '',
     type: 'STUDENT_AND_PARENT',
     applicationStartDate: null,
@@ -20,8 +25,8 @@ export const useEditFairForm = (fairId: number) => {
   useEffect(() => {
     if (fairData) {
       setEditFair({
-        start: fairData.start,
-        capacity: fairData.capacity,
+        start: toRawDateTime(fairData.start),
+        capacity: String(fairData.capacity),
         place: fairData.place,
         type: fairData.type,
         applicationStartDate: fairData.applicationStartDate,
@@ -35,7 +40,7 @@ export const useEditFairForm = (fairId: number) => {
   };
 
   const handleEditFair = () => {
-    putFairMutate(editFair);
+    putFairMutate(formatFairRequestBody(editFair));
   };
 
   const handleChange = <K extends keyof FairFormInput>(

--- a/apps/admin/src/components/fair/EditFairForm/editFairForm.hooks.ts
+++ b/apps/admin/src/components/fair/EditFairForm/editFairForm.hooks.ts
@@ -28,7 +28,7 @@ export const useEditFairForm = (fairId: number) => {
         start: toRawDateTime(fairData.start),
         capacity: String(fairData.capacity),
         place: fairData.place,
-        type: fairData.type,
+        type: fairData.fairType,
         applicationStartDate: fairData.applicationStartDate,
         applicationEndDate: fairData.applicationEndDate,
       });

--- a/apps/admin/src/types/fair/client.ts
+++ b/apps/admin/src/types/fair/client.ts
@@ -46,7 +46,7 @@ export interface FairDetailData {
   start: string;
   place: string;
   capacity: number;
-  type: FairType;
+  fairType: FairType;
   applicationStartDate: string;
   applicationEndDate: string;
   status: FairStatus;


### PR DESCRIPTION
## 📄 Summary

> 입학설명회 수정 페이지에서 일시가 다르게 표시되고, 저장 시 400 에러(LocalDateTime 파싱 실패)가 발생하던 버그를 수정했습니다

<br>

## 🔨 Tasks

- 서버 응답의 ISO 형식 start를 폼에서 쓰는 12자리 형식으로 정규화해 일시 표시 오류 수정
- 수정 저장 시 생성과 동일하게 formatFairRequestBody 변환을 거쳐 요청하도록 수정
- 상세 응답 필드명 불일치(type → fairType) 수정으로 대상 선택 라디오 미선택/누락 문제 해결

<br>

## 🙋🏻 More
